### PR TITLE
Add file permission steps to "add-ssh-auth-new-server" post

### DIFF
--- a/docs/tricks/add-ssh-auth-new-server.md
+++ b/docs/tricks/add-ssh-auth-new-server.md
@@ -17,7 +17,7 @@ if server is new creation and doesnt have a ssh file.
 ```bash
  mkdir ~/.ssh && touch ~/.ssh/authorized_keys &&
  echo 'ssh-rsa is here' >> ~/.ssh/authorized_keys &&
- chmod 700 .ssh && chmod 600 .ssh/authorized_keys
+ chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys
 ```
 
 already ssh folder

--- a/docs/tricks/add-ssh-auth-new-server.md
+++ b/docs/tricks/add-ssh-auth-new-server.md
@@ -16,7 +16,8 @@ if server is new creation and doesnt have a ssh file.
 
 ```bash
  mkdir ~/.ssh && touch ~/.ssh/authorized_keys &&
- echo 'ssh-rsa is here' >> ~/.ssh/authorized_keys
+ echo 'ssh-rsa is here' >> ~/.ssh/authorized_keys &&
+ chmod 700 .ssh && chmod 600 .ssh/authorized_keys
 ```
 
 already ssh folder


### PR DESCRIPTION
SSH files should be readable for only the file's users.
Otherwise It may be show an error message while using SSH.